### PR TITLE
Small refactor to character switcher

### DIFF
--- a/entities/player/attacks/Bullet.tscn
+++ b/entities/player/attacks/Bullet.tscn
@@ -5,20 +5,21 @@
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_tejt7"]
 size = Vector2(2, 2)
 
-[node name="Bullet" type="Area2D"]
+[node name="Bullet" type="Area2D" unique_id=723863815]
 script = ExtResource("1_4ck4c")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="ColorRect" type="ColorRect" parent="." unique_id=664844149]
 offset_left = -1.0
 offset_top = -1.0
 offset_right = 1.0
 offset_bottom = 1.0
 color = Color(0.9538683, 0, 0.23396993, 1)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=834031990]
 shape = SubResource("RectangleShape2D_tejt7")
 
-[node name="Timer" type="Timer" parent="."]
+[node name="Timer" type="Timer" parent="." unique_id=1257420532]
+autostart = true
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]
 [connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]

--- a/entities/player/character_manager.gd
+++ b/entities/player/character_manager.gd
@@ -1,12 +1,10 @@
-extends Node
+extends Node2D
 class_name character_manager
 
 signal swapping_character
 
 # the scene name of each character
 enum characters {blue_knight, yellow_knight}
-
-const NAME_OF_NODE := "character_slot"
 
 var path := "res://entities/player/character_scenes/"
 
@@ -23,11 +21,11 @@ func _ready() -> void:
 
 func _physics_process(_delta: float) -> void:
 	if Input.is_action_just_pressed("character_change"):
-		swapping_character.emit()
+		get_child(0).swap_character()
 		switch_next()
 
 func _do_switch(target_character: String = "") -> void:
-	var old_node: main_character = get_parent().get_node(NAME_OF_NODE)
+	var old_node: main_character = get_child(0)
 	var new_node: main_character
 	if target_character != "":
 		new_node = character_nodes[characters.get(target_character)]
@@ -37,17 +35,10 @@ func _do_switch(target_character: String = "") -> void:
 	# transfer the current pos
 	new_node.global_position = old_node.global_position
 	
-	var parent = old_node.get_parent()
-	# move receiver of the swapping signal (preventing state carryover, ideally)
-	if swapping_character.is_connected(old_node._on_swapping_character):
-		swapping_character.disconnect(old_node._on_swapping_character)
-	swapping_character.connect(new_node._on_swapping_character)
-	
 	# replace instances - swap characters
-	parent.add_child(new_node)
-	parent.move_child(new_node, old_node.get_index())
-	parent.remove_child(old_node)
-	new_node.name = NAME_OF_NODE
+	add_child(new_node)
+	move_child(new_node, 0)
+	remove_child(old_node)
 	
 	# maintain speed - should not exceed character's maximum
 	var direction := old_node.velocity.normalized()
@@ -62,6 +53,10 @@ func switch_to(target_character: String) -> void:
 	
 ## Returns Node of next character in the `character_nodes` array.
 func get_next() -> main_character:
-	character_index = (character_index + 1) % characters.size()
-	return character_nodes[character_index]
+	var next_character
+	while !next_character:
+		character_index = (character_index + 1) % characters.size()
+		if character_nodes[character_index].is_alive:
+			next_character = character_nodes[character_index]
+	return next_character
 	

--- a/entities/player/main_character.gd
+++ b/entities/player/main_character.gd
@@ -15,6 +15,7 @@ enum evadeState {READY, ACTIVE, COOLDOWN}
 
 var attack_cooldown := false
 var evade_flag = evadeState.READY
+var is_alive := true
 
 func _ready() -> void:
 	add_to_group("Player")
@@ -73,7 +74,7 @@ func _on_evade_timeout() -> void:
 	elif evade_flag == evadeState.COOLDOWN:
 		evade_flag = evadeState.READY
 
-func _on_swapping_character() -> void:
+func swap_character() -> void:
 	# dodge should skip straight to cooldown to prevent abuse
 	evade_flag = evadeState.COOLDOWN
 	handle_animation() # force change animation away from dodge

--- a/main/main.gd
+++ b/main/main.gd
@@ -2,7 +2,7 @@ extends Node2D
 
 @onready var cm:=$character_manager
 @onready var room_manager := $Room_manager
-@onready var character := $character_slot
+@onready var character := $character_manager/character_slot
 
 
 func _ready() -> void:

--- a/main/main.tscn
+++ b/main/main.tscn
@@ -457,8 +457,8 @@ script = ExtResource("2_21xkr")
 [node name="Hallway" type="TileMapLayer" parent="Room_manager" unique_id=1399369055]
 tile_set = SubResource("TileSet_8gbba")
 
-[node name="character_slot" parent="." unique_id=1328872590 instance=ExtResource("2_bo1nx")]
-position = Vector2(576, 325)
-
-[node name="character_manager" type="Node" parent="." unique_id=1573431383]
+[node name="character_manager" type="Node2D" parent="." unique_id=1655392748]
 script = ExtResource("4_jjvhh")
+
+[node name="character_slot" parent="character_manager" unique_id=1328872590 instance=ExtResource("2_bo1nx")]
+position = Vector2(576, 325)


### PR DESCRIPTION
Refactored character switcher to streamline the switching process:
- changed character switcher to be a node2d with position
- moved character_slot to be a child of character switcher
- current character is found using get_child(0) rather than by name of node.
- since its now a child it calls the switch character method in the character rather than uses a signal
- character switcher checks if the is_alive flag in character is true. if false it continues to next alive character

TODO:
- make the character switcher spawn the first character at the right position (needed for when the first character is not blue knight)
- a way to rearrange the enum order from a ui (needs ui)
- a way to add and remove a character from the enum and then load just that character (needs more characters)

BUGS:
- the dodge roll cooldown timer is causing delays after switching before the character is allowed to dodge roll again. will return to this after yellow knight no longer inherits blue knight.