### PR TITLE
Small Fixes to Enemy Class

### DIFF
--- a/Room_scenes/room_template.gd
+++ b/Room_scenes/room_template.gd
@@ -118,7 +118,7 @@ func _on_south_door_body_exited(body: Node2D) -> void:
 
 # only mask on player layer
 func _on_room_activator_body_entered(body: Node2D) -> void:
-	if body is main_character and enemy_list:
+	if not locked and body is main_character and enemy_list:
 		locked = true
 		print("room locked")
 		for enemy in enemy_list:

--- a/entities/enemy/Enemy.tscn
+++ b/entities/enemy/Enemy.tscn
@@ -43,7 +43,7 @@ _data = {
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_pux1x"]
 radius = 4.0
-height = 20.0
+height = 12.0
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_cn5l5"]
 radius = 1.0

--- a/entities/enemy/Enemy_scenes/BasicRangedEnemy.tscn
+++ b/entities/enemy/Enemy_scenes/BasicRangedEnemy.tscn
@@ -428,5 +428,5 @@ rotation = 1.5707964
 [node name="CollisionShape2D" parent="Hitbox" index="0" unique_id=946156460]
 position = Vector2(-6, -0.9999997)
 
-[node name="attack_offset" type="Marker2D" parent="." index="10" unique_id=549747348]
+[node name="AttackOffset" type="Marker2D" parent="." index="10" unique_id=549747348]
 position = Vector2(-6, -9)

--- a/entities/enemy/basic_melee/basic_melee_enemy.gd
+++ b/entities/enemy/basic_melee/basic_melee_enemy.gd
@@ -6,6 +6,7 @@ const DAMAGE := 15
 const SPEED := 50.0
 const ACCELERATION := 20.0
 const HP := 100
+const WEIGHT := 0.5
 const KNOCKBACK := 300
 const ATTACKS_PER_SECOND := 1.5
 
@@ -22,6 +23,7 @@ func _ready() -> void:
 	move_speed = SPEED
 	accel = ACCELERATION
 	health.set_health(HP)
+	mass_coef = WEIGHT
 	attack_sprite.visible = false
 	super()
 

--- a/entities/enemy/basic_melee/basic_melee_enemy.gd
+++ b/entities/enemy/basic_melee/basic_melee_enemy.gd
@@ -29,8 +29,9 @@ func _ready() -> void:
 func _physics_process(delta: float) -> void:
 	if raycast_target and not attack_cooldown:
 		attack_visual.look_at(raycast_target.global_position)
-	# once maincharacter enters attack range checks each frame if they are still in range
-	if attack_mode and !attack_cooldown:
+		
+	# checks if character in range, per frame, while in attack phase
+	if attack_mode and !attack_cooldown and enemyState == BEHAVIOUR.ATTACK:
 		var bodies = detect_radius.get_overlapping_bodies()
 		for body in bodies:
 			if body is main_character:

--- a/entities/enemy/basic_ranged/basic_ranged_enemy.gd
+++ b/entities/enemy/basic_ranged/basic_ranged_enemy.gd
@@ -1,9 +1,11 @@
 extends Enemy
+class_name RangedEnemy
 
 const PROJECTILE := preload("res://entities/enemy/components/projectile/enemy_projectile.tscn") 
 const SPEED := 15.0
 const ACCELERATION := 10.0
 const HP := 100
+const WEIGHT := 2
 const ATTACKS_PER_SECOND := 1.0
 const PROJECTILE_SPEED := 75
 const ORBIT_DIST := 80.0
@@ -15,12 +17,14 @@ var frame := 0
 func _ready() -> void:
 	move_speed = SPEED
 	accel = ACCELERATION
+	mass_coef = WEIGHT
 	health.set_health(HP)
 	super()
 	
 
 func attack_logic() -> void:
-	var attack_offset = $attack_offset.position * _look_vector_direction(global_position.direction_to(raycast_target.global_position))
+	var attack_offset = $AttackOffset.position * _look_vector_direction(
+			global_position.direction_to(raycast_target.global_position))
 	var player_enemy_vec :Vector2 = global_position - raycast_target.global_position + attack_offset
 	var player_enemy_direction := player_enemy_vec.normalized()
 	var player_enemy_dist := player_enemy_vec.length()
@@ -28,11 +32,14 @@ func attack_logic() -> void:
 	if frame % 10 == 0:
 		# if not in range, move within chase range
 		if player_enemy_dist > CHASE_DIST:
-			nav_agent.target_position = raycast_target.global_position + (player_enemy_direction * ORBIT_DIST)
+			nav_agent.target_position = (raycast_target.global_position +
+					(player_enemy_direction * ORBIT_DIST))
 		# if in range, orbit path around player (random cw or acw)
 		elif nav_agent.is_navigation_finished():
-			var orbit_vector = player_enemy_direction.rotated(randf_range(-PI / 4, PI / 4))
-			nav_agent.target_position = raycast_target.global_position + (orbit_vector * ORBIT_DIST)
+			var orbit_vector = player_enemy_direction.rotated(
+					randf_range(-PI / 4, PI / 4))
+			nav_agent.target_position = (raycast_target.global_position
+					+ (orbit_vector * ORBIT_DIST))
 	frame += 1
 	
 	if not attack_cooldown:

--- a/entities/enemy/enemy.gd
+++ b/entities/enemy/enemy.gd
@@ -67,7 +67,7 @@ func _physics_process(delta: float) -> void:
 			_look_vector_direction(velocity)
 		
 	elif enemyState == BEHAVIOUR.ATTACK:
-		if !raycast_target.is_inside_tree():
+		if !raycast_target.is_inside_tree(): # locks to new character on swap
 			raycast_target = get_tree().get_first_node_in_group("Player")
 		attack_logic()
 		# look in direction of player
@@ -189,7 +189,6 @@ func _on_knockback_timer_timeout() -> void:
 
 func _on_hitbox_area_entered(area: Area2D) -> void:
 	if !knockback:
-		var direction = (global_position - area.global_position).normalized()
 		take_damage(area.deal_damage(), area)
 	else:
 		area.queue_free()

--- a/entities/enemy/enemy.gd
+++ b/entities/enemy/enemy.gd
@@ -111,12 +111,16 @@ func _on_wander_timeout() -> void:
 ## - removes instance after animation plays
 func _on_death() -> void:
 	animation.no_interrupt = false
-	animation.play_animation("death", true)
+	hitbox.set_deferred("disabled", true)
+	
 	enemyState = BEHAVIOUR.DEAD
 	knockback_vec = Vector2.ZERO
+	set_physics_process(false)
 	collision_layer = 0
+	collision_mask = 0
 	nav_agent.set_velocity(Vector2.ZERO)
-	hitbox.set_deferred("disabled", true)
+
+	animation.play_animation("death", true)
 	await animation.animation_finished
 	get_parent().enemy_died()
 	queue_free()

--- a/entities/enemy/enemy.gd
+++ b/entities/enemy/enemy.gd
@@ -23,6 +23,7 @@ var stop_moving := false
 
 var knockback_dur := 0.2
 var knockback_vec := Vector2.ZERO
+var mass_coef: float
 
 @onready var wander_timer := $WanderTimer
 @onready var attack_timer := $AttackTimer
@@ -84,7 +85,7 @@ func _move(_delta: float) -> void:
 	animation.play_animation("moving")
 	
 
-func _look_vector_direction(direction: Vector2):
+func _look_vector_direction(direction: Vector2) -> Vector2:
 	# enemy looks left or right based on vector.x
 	if direction.x < 0:
 		visual.scale.x = -1
@@ -182,7 +183,7 @@ func attack_logic() -> void:
 	pass
 
 func apply_knockback(direction: Vector2, scalar: int = KB_AMOUNT) -> void:
-	knockback_vec += (direction * scalar)
+	knockback_vec += (direction * scalar / mass_coef)
 	knockback = true
 	knockback_timer.start(knockback_dur)
 


### PR DESCRIPTION
**This PR addresses some small issues with the enemy implementation. Closes #56. Closes #60.**

## Key Changes
- Room lock conditions adjusted, so swapping characters doesn't re-lock the room.
  - This also prevents enemy reactivation when swapping, deaggroing, thus preventing weird behaviour.
- Melee Enemy no longer attacks during the death animation.
- Enemies no longer collide during the death animation.
- Implemented weight coefficients onto enemies, causing varying amount of knockback regardless of movement speed.