### PR TITLE
Audio

### DIFF
--- a/entities/enemy/basic_melee/basic_melee_enemy.gd
+++ b/entities/enemy/basic_melee/basic_melee_enemy.gd
@@ -65,6 +65,7 @@ func _on_attack_render_timeout() -> void:
 	attack_box.toggle_disable(true)
 
 func melee_attack():
+		SFX_Manager.play_sound_effect_from_dictionary("swipe")
 		attack_sprite.visible = true
 		attack_sprite.frame = randi() % 4
 		attack_box.toggle_disable(false)

--- a/entities/enemy/basic_ranged/basic_ranged_enemy.gd
+++ b/entities/enemy/basic_ranged/basic_ranged_enemy.gd
@@ -27,6 +27,7 @@ func _ready() -> void:
 	super()
 
 func fire_bullet(dir: Vector2, pos: Vector2):
+	SFX_Manager.play_sound_effect_from_dictionary("whoosh_2")
 	var attack := PROJECTILE.instantiate()
 	animation.play_animation("attack", true)
 	attack.set_velocity(dir * PROJECTILE_SPEED)

--- a/entities/enemy/enemy.gd
+++ b/entities/enemy/enemy.gd
@@ -166,6 +166,7 @@ func deactivate_enemy() -> void:
 
 
 func take_damage(amount: int, from: Area2D, knockback_scalar : int = KB_AMOUNT) -> void:
+	SFX_Manager.play_sound_effect_from_dictionary("kick")
 	if enemyState == BEHAVIOUR.DEAD:
 		return
 	if enemyState == BEHAVIOUR.WANDER:

--- a/entities/player/base_character/SFX_Manager.gd
+++ b/entities/player/base_character/SFX_Manager.gd
@@ -25,3 +25,7 @@ func play_sound_effect_from_dictionary(_tag: String)->void:
 		audio_stream_playback.play_stream(audio_stream)
 	else:
 			printerr("no tag provided")
+
+
+func update_position(node: Node2D):
+	position = node.position

--- a/entities/player/base_character/SFX_Manager.gd
+++ b/entities/player/base_character/SFX_Manager.gd
@@ -5,6 +5,7 @@ extends AudioStreamPlayer2D
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	stream =AudioStreamPolyphonic.new()
+	stream.polyphony = 64
 	volume_db = 0
 	pass # Replace with function body.
 

--- a/entities/player/base_character/main_character.gd
+++ b/entities/player/base_character/main_character.gd
@@ -54,6 +54,7 @@ func _process(_delta: float) -> void:
 			char_visual.scale.x = -1
 		else:
 			char_visual.scale.x = 1
+	SFX_Manager.update_position(self)
 	
 func _physics_process(delta: float) -> void:
 	var direction = Input.get_vector("left", "right", "up", "down")

--- a/entities/player/base_character/main_character.gd
+++ b/entities/player/base_character/main_character.gd
@@ -171,6 +171,7 @@ func add_knockback(vec: Vector2) -> void:
 func take_damage(amount: int):
 	# if you are hit you still get knocked back but do not take damage if in iframe
 	if !iframe_flag:
+		SFX_Manager.play_sound_effect_from_dictionary("slap")
 		char_visual.modulate = Color(2,2,2)
 		iframe_timer.start(IFRAME_DUR)
 		iframe_flag = true

--- a/entities/player/character_manager.gd
+++ b/entities/player/character_manager.gd
@@ -68,7 +68,7 @@ func _do_switch(target_character: String = "") -> void:
 	new_node.global_position = old_node.global_position
 	
 	#debug
-	## print(character_nodes)
+	# print(character_nodes)
 	# replace instances - swap characters
 	
 	

--- a/main/background_audio_manager.gd
+++ b/main/background_audio_manager.gd
@@ -4,10 +4,18 @@ extends Node2D
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	get_child(rand_index).playing = true	
-	pass # Replace with function body.
+	for audio_stream in get_children():
+			audio_stream.volume_db = -10
 
 func _process(_delta: float) -> void:
 	position = $"../character_manager".get_child(0).position
+	if Input.is_action_just_pressed("sfx_volume_up"):
+		for audio_stream in get_children():
+			audio_stream.volume_db += 2
+	if Input.is_action_just_pressed("sfx_volume_down"):
+		for audio_stream in get_children():
+			audio_stream.volume_db -= 2
+	
 
 func _on_audio_stream_player_2d_finished() -> void:
 	var new_rand_index = randi()%get_child_count()

--- a/main/main.tscn
+++ b/main/main.tscn
@@ -832,17 +832,17 @@ script = ExtResource("14_5xyti")
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="background_audio_manager" unique_id=948336295]
 stream = ExtResource("14_73k8k")
-volume_db = -33.133
+volume_db = -5.0
 max_distance = 4096.0
 
 [node name="AudioStreamPlayer2D2" type="AudioStreamPlayer2D" parent="background_audio_manager" unique_id=2134412468]
 stream = ExtResource("16_s758e")
-volume_db = -33.133
+volume_db = -5.0
 max_distance = 4096.0
 
 [node name="AudioStreamPlayer2D3" type="AudioStreamPlayer2D" parent="background_audio_manager" unique_id=932146079]
 stream = ExtResource("17_4hmqs")
-volume_db = -33.133
+volume_db = -5.0
 max_distance = 4096.0
 
 [connection signal="character_removed" from="character_manager/character_hud" to="character_manager" method="_on_character_hud_character_removed"]


### PR DESCRIPTION
### Bug fixes and added sfx
- sfx not following the player fixed
- background music now start louder and can be turned up or down
- enemy attack, enemy dmg, player damage now have corresponding sfx
- the sfx polyphonic can now play 64 audio streams before reseting the replacing an audio stream